### PR TITLE
Fix Issue Where Reading Cut Short on Initial Load

### DIFF
--- a/src/AllReadings.tsx
+++ b/src/AllReadings.tsx
@@ -39,7 +39,9 @@ export const AllReadings = () => {
       }
     });
   };
-  const onSwipeableViewsMount = async (actions: { updateHeight: () => void}): Promise<void> => {
+  const onSwipeableViewsMount = async (actions: {
+    updateHeight: () => void;
+  }): Promise<void> => {
     await new Promise((r) => setTimeout(r, 1000));
     actions.updateHeight();
   };

--- a/src/AllReadings.tsx
+++ b/src/AllReadings.tsx
@@ -39,6 +39,10 @@ export const AllReadings = () => {
       }
     });
   };
+  const onSwipeableViewsMount = async (actions: { updateHeight: () => void}): Promise<void> => {
+    await new Promise((r) => setTimeout(r, 1000));
+    actions.updateHeight();
+  };
 
   return (
     <>
@@ -86,6 +90,8 @@ export const AllReadings = () => {
         onChangeIndex={(index: number, indexLatest: number) => {
           setSelectedReadingIndex(index);
         }}
+        // @ts-ignore
+        action={onSwipeableViewsMount}
       >
         {readings.map((_, i) => (
           <ReadingDay


### PR DESCRIPTION
This is a super hacky fix, but I couldn't figure out any other way to fix the issue. I tried waiting until the components within the swipeable view were mounted, but that didn't work :-(